### PR TITLE
Upgrade C++ standard from C++20 to C++23

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is **akbench** (formerly ipc-bench), an IPC and system performance benchmarking tool written in C++23. The project measures both bandwidth and latency for various inter-process communication mechanisms and system operations.
+
+### Core Architecture
+
+The project has a modular design with two main entry points:
+- **akbench.cc**: Unified benchmark runner that combines both latency and bandwidth tests
+- **bandwidth.cc** & **latency.cc**: Legacy separate executables (still available)
+
+Each IPC/system operation is implemented as a separate library with a consistent interface:
+- **Bandwidth libraries**: `*_bandwidth.{cc,h}` (memcpy, tcp, uds, pipe, fifo, mq, mmap, shm, etc.)
+- **Latency libraries**: `*_latency.{cc,h}` (atomic, barrier, condition_variable, semaphore, syscall)
+
+All libraries link against `AKBENCH_LIBS` which includes Abseil dependencies and common utilities.
+
+## Development Commands
+
+### Build
+```bash
+./scripts/build.sh
+```
+This script:
+- Updates git submodules (Abseil)
+- Uses clang++ with ccache for faster rebuilds
+- Builds with RelWithDebInfo and Ninja
+- Generates compile_commands.json for IDE support
+
+### Format Code
+```bash
+./scripts/format.sh
+```
+Uses clang-format-18 for C++ files and cmake-format for CMake files.
+
+### Run Tests
+```bash
+# Build first, then run tests
+./scripts/build.sh
+ctest --test-dir build
+# or
+cd build && ctest
+```
+
+Only one test currently exists: `barrier_test`
+
+### Run Benchmarks
+```bash
+# Bandwidth benchmarks (1GB data, 10 iterations, 3 warmups)
+./build/akbench/akbench --type=all_bandwidth --data_size=$((1 << 30)) --num_iterations=10 --num_warmups=3
+
+# Latency benchmarks 
+./build/akbench/akbench --type=all_latency
+
+# Run everything
+./build/akbench/akbench --type=all --data_size=$((1 << 30)) --num_iterations=10 --num_warmups=3
+
+# Legacy individual binaries also available:
+./build/akbench/bandwidth --type=all --data_size=$((1 << 30)) --num_iterations=10 --num_warmups=3
+./build/akbench/latency --type=all
+```
+
+## Key Technical Details
+
+- **C++23** standard required
+- **Abseil** for logging, flags, synchronization primitives
+- **CMake** build system with Ninja generator
+- **ccache** for build acceleration
+- Uses **Abseil flags** for command-line argument parsing
+- Consistent measurement methodology with warmup iterations
+
+## Adding New Benchmarks
+
+1. Create `new_benchmark.{cc,h}` in `akbench/`
+2. Add library target in `akbench/CMakeLists.txt`
+3. Link the library to the appropriate executable(s)
+4. Follow existing patterns for flag handling and measurement loops
+5. Use `common.h` utilities for data generation and verification
+
+## MPI Support
+
+The project includes MPI bandwidth benchmarks (`mpi_bandwidth.cc`) which require MPI to be installed on the system.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.20)
 project(akbench LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 enable_testing()


### PR DESCRIPTION
## Summary
- Update CMAKE_CXX_STANDARD to 23 in root CMakeLists.txt
- Update CLAUDE.md documentation

## Test plan
- [ ] Verify project builds with C++23
- [ ] Run existing tests