### PR TITLE
Add branch creation requirement to pre-PR checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,8 +106,14 @@ void process_data(std::vector<uint8_t>& data, bool& success);
 
 ## Pre-PR Checklist
 
-Before creating a pull request, always run:
+Before creating a pull request, always:
 
+1. **Create a new branch** for your work:
+```bash
+git checkout -b your-feature-branch-name
+```
+
+2. **Build and format** to ensure code quality:
 ```bash
 # Build the project to ensure compilation succeeds
 ./scripts/build.sh
@@ -116,7 +122,7 @@ Before creating a pull request, always run:
 ./scripts/format.sh
 ```
 
-These commands ensure code quality and consistency across the project.
+These steps ensure code quality and consistency across the project.
 
 ## Git Commit Guidelines
 


### PR DESCRIPTION
## Summary
- Add explicit instruction to create a new branch before starting PR work in CLAUDE.md
- Update Pre-PR Checklist to include branching as the first step
- Ensures proper development workflow and avoids working directly on main

## Test plan
- [x] Verify CLAUDE.md formatting is correct
- [x] Confirm checklist flows logically from branch creation to build/format
- [x] Check that changes align with existing documentation style