### PR TITLE
Add standard deviation to benchmark results

### DIFF
--- a/akbench/atomic_latency.cc
+++ b/akbench/atomic_latency.cc
@@ -42,8 +42,8 @@ void ChildFlip(std::atomic<bool> *child, const std::atomic<bool> &parent,
 
 } // namespace
 
-double RunAtomicLatencyBenchmark(int num_iterations, int num_warmups,
-                                 uint64_t loop_size) {
+BenchmarkResult RunAtomicLatencyBenchmark(int num_iterations, int num_warmups,
+                                          uint64_t loop_size) {
   std::atomic<bool> parent{false}, child{false};
 
   std::vector<double> durations;

--- a/akbench/atomic_latency.h
+++ b/akbench/atomic_latency.h
@@ -2,5 +2,7 @@
 
 #include <cstdint>
 
-double RunAtomicLatencyBenchmark(int num_iterations, int num_warmups,
-                                 uint64_t loop_size);
+#include "common.h"
+
+BenchmarkResult RunAtomicLatencyBenchmark(int num_iterations, int num_warmups,
+                                          uint64_t loop_size);

--- a/akbench/atomic_latency_test.cc
+++ b/akbench/atomic_latency_test.cc
@@ -10,10 +10,10 @@ int main(int argc, char *argv[]) {
   constexpr int num_warmups = 0;
   constexpr uint64_t loop_size = 10;
 
-  const double latency =
+  const BenchmarkResult result =
       RunAtomicLatencyBenchmark(num_iterations, num_warmups, loop_size);
 
-  AKCHECK(latency >= 0.0, "Latency should be non-negative");
+  AKCHECK(result.average >= 0.0, "Latency should be non-negative");
   AKLOG(aklog::LogLevel::INFO, "atomic_latency test passed");
 
   return 0;

--- a/akbench/barrier_latency.cc
+++ b/akbench/barrier_latency.cc
@@ -27,8 +27,8 @@ void ChildBarrierProcess(uint64_t loop_size) {
 
 } // namespace
 
-double RunBarrierLatencyBenchmark(int num_iterations, int num_warmups,
-                                  uint64_t loop_size) {
+BenchmarkResult RunBarrierLatencyBenchmark(int num_iterations, int num_warmups,
+                                           uint64_t loop_size) {
   // Clear any existing barrier resources
   SenseReversingBarrier::ClearResource(BARRIER_ID);
 
@@ -97,10 +97,14 @@ double RunBarrierLatencyBenchmark(int num_iterations, int num_warmups,
     SenseReversingBarrier::ClearResource(BARRIER_ID);
   }
 
-  // Calculate and return median latency in seconds
-  double median_latency_ns = CalculateOneTripDuration(measurements);
+  // Calculate and return latency statistics
+  BenchmarkResult result = CalculateOneTripDuration(measurements);
   AKLOG(aklog::LogLevel::DEBUG,
-        std::format("Barrier latency (median): {} ns", median_latency_ns));
+        std::format("Barrier latency (average): {} ns", result.average));
 
-  return median_latency_ns / 1e9; // Convert to seconds
+  // Convert from nanoseconds to seconds
+  result.average /= 1e9;
+  result.stddev /= 1e9;
+
+  return result;
 }

--- a/akbench/barrier_latency.h
+++ b/akbench/barrier_latency.h
@@ -2,5 +2,7 @@
 
 #include <cstdint>
 
-double RunBarrierLatencyBenchmark(int num_iterations, int num_warmups,
-                                  uint64_t loop_size);
+#include "common.h"
+
+BenchmarkResult RunBarrierLatencyBenchmark(int num_iterations, int num_warmups,
+                                           uint64_t loop_size);

--- a/akbench/barrier_latency_test.cc
+++ b/akbench/barrier_latency_test.cc
@@ -10,10 +10,10 @@ int main(int argc, char *argv[]) {
   constexpr int num_warmups = 0;
   constexpr uint64_t loop_size = 10;
 
-  const double latency =
+  const BenchmarkResult result =
       RunBarrierLatencyBenchmark(num_iterations, num_warmups, loop_size);
 
-  AKCHECK(latency >= 0.0, "Latency should be non-negative");
+  AKCHECK(result.average >= 0.0, "Latency should be non-negative");
   AKLOG(aklog::LogLevel::INFO, "barrier_latency test passed");
 
   return 0;

--- a/akbench/common.h
+++ b/akbench/common.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -5,11 +7,16 @@
 constexpr uint64_t CHECKSUM_SIZE = 128;
 constexpr const char *GIBYTE_PER_SEC_UNIT = " GiByte/sec";
 
+struct BenchmarkResult {
+  double average;
+  double stddev;
+};
+
 std::vector<uint8_t> GenerateDataToSend(uint64_t data_size);
 bool VerifyDataReceived(const std::vector<uint8_t> &data, uint64_t data_size);
-double CalculateBandwidth(std::vector<double> durations, int num_iterations,
-                          uint64_t data_size);
-double CalculateOneTripDuration(const std::vector<double> &durations);
+BenchmarkResult CalculateBandwidth(std::vector<double> durations,
+                                   int num_iterations, uint64_t data_size);
+BenchmarkResult CalculateOneTripDuration(const std::vector<double> &durations);
 std::string ReceivePrefix(int iteration);
 std::string SendPrefix(int iteration);
 std::string GenerateUniqueName(const std::string &base_name);

--- a/akbench/condition_variable_latency.cc
+++ b/akbench/condition_variable_latency.cc
@@ -53,8 +53,9 @@ void ChildFlip(std::condition_variable *parent_cv,
 
 } // namespace
 
-double RunConditionVariableLatencyBenchmark(int num_iterations, int num_warmups,
-                                            uint64_t loop_size) {
+BenchmarkResult RunConditionVariableLatencyBenchmark(int num_iterations,
+                                                     int num_warmups,
+                                                     uint64_t loop_size) {
   std::condition_variable parent_cv, child_cv;
   std::mutex parent_mutex, child_mutex;
   bool parent_ready = false, child_ready = false;

--- a/akbench/condition_variable_latency.h
+++ b/akbench/condition_variable_latency.h
@@ -2,5 +2,8 @@
 
 #include <cstdint>
 
-double RunConditionVariableLatencyBenchmark(int num_iterations, int num_warmups,
-                                            uint64_t loop_size);
+#include "common.h"
+
+BenchmarkResult RunConditionVariableLatencyBenchmark(int num_iterations,
+                                                     int num_warmups,
+                                                     uint64_t loop_size);

--- a/akbench/condition_variable_latency_test.cc
+++ b/akbench/condition_variable_latency_test.cc
@@ -10,10 +10,10 @@ int main(int argc, char *argv[]) {
   constexpr int num_warmups = 0;
   constexpr uint64_t loop_size = 10;
 
-  const double latency = RunConditionVariableLatencyBenchmark(
+  const BenchmarkResult result = RunConditionVariableLatencyBenchmark(
       num_iterations, num_warmups, loop_size);
 
-  AKCHECK(latency >= 0.0, "Latency should be non-negative");
+  AKCHECK(result.average >= 0.0, "Latency should be non-negative");
   AKLOG(aklog::LogLevel::INFO, "condition_variable_latency test passed");
 
   return 0;

--- a/akbench/fifo_bandwidth.cc
+++ b/akbench/fifo_bandwidth.cc
@@ -77,18 +77,19 @@ void SendProcess(int num_warmups, int num_iterations, uint64_t data_size,
     close(write_fd);
   }
 
-  double bandwidth = CalculateBandwidth(durations, num_iterations, data_size);
+  BenchmarkResult result =
+      CalculateBandwidth(durations, num_iterations, data_size);
 
-  double bandwidth_gibps = bandwidth / (1024.0 * 1024.0 * 1024.0);
   AKLOG(aklog::LogLevel::INFO,
-        std::format("Send bandwidth: {}{}.", bandwidth_gibps,
+        std::format("Send bandwidth: {:.3f} ± {:.3f}{}.",
+                    result.average / (1 << 30), result.stddev / (1 << 30),
                     GIBYTE_PER_SEC_UNIT));
 
   AKLOG(aklog::LogLevel::DEBUG, std::format("{}Exiting.", SendPrefix(-1)));
 }
 
-double ReceiveProcess(int num_warmups, int num_iterations, uint64_t data_size,
-                      uint64_t buffer_size) {
+BenchmarkResult ReceiveProcess(int num_warmups, int num_iterations,
+                               uint64_t data_size, uint64_t buffer_size) {
   SenseReversingBarrier barrier(2, BARRIER_ID);
 
   std::vector<double> durations;
@@ -163,20 +164,23 @@ double ReceiveProcess(int num_warmups, int num_iterations, uint64_t data_size,
     close(read_fd);
   }
 
-  double bandwidth = CalculateBandwidth(durations, num_iterations, data_size);
+  BenchmarkResult result =
+      CalculateBandwidth(durations, num_iterations, data_size);
   AKLOG(aklog::LogLevel::INFO,
-        std::format("Receive bandwidth: {}{}.", bandwidth / (1 << 30),
+        std::format("Receive bandwidth: {:.3f} ± {:.3f}{}.",
+                    result.average / (1 << 30), result.stddev / (1 << 30),
                     GIBYTE_PER_SEC_UNIT));
 
   AKLOG(aklog::LogLevel::DEBUG, std::format("{}Exiting.", ReceivePrefix(-1)));
 
-  return bandwidth;
+  return result;
 }
 
 } // namespace
 
-double RunFifoBandwidthBenchmark(int num_iterations, int num_warmups,
-                                 uint64_t data_size, uint64_t buffer_size) {
+BenchmarkResult RunFifoBandwidthBenchmark(int num_iterations, int num_warmups,
+                                          uint64_t data_size,
+                                          uint64_t buffer_size) {
   // Remove any existing FIFO
   unlink(FIFO_PATH.c_str());
 
@@ -197,7 +201,7 @@ double RunFifoBandwidthBenchmark(int num_iterations, int num_warmups,
     exit(0);
   } else {
     // Parent process: receiver
-    double bandwidth =
+    BenchmarkResult result =
         ReceiveProcess(num_warmups, num_iterations, data_size, buffer_size);
     waitpid(pid, nullptr, 0);
 
@@ -205,6 +209,6 @@ double RunFifoBandwidthBenchmark(int num_iterations, int num_warmups,
     unlink(FIFO_PATH.c_str());
     SenseReversingBarrier::ClearResource(BARRIER_ID);
 
-    return bandwidth;
+    return result;
   }
 }

--- a/akbench/fifo_bandwidth.h
+++ b/akbench/fifo_bandwidth.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "common.h"
 #include <cstdint>
 
-double RunFifoBandwidthBenchmark(int num_iterations, int num_warmups,
-                                 uint64_t data_size, uint64_t buffer_size);
+BenchmarkResult RunFifoBandwidthBenchmark(int num_iterations, int num_warmups,
+                                          uint64_t data_size,
+                                          uint64_t buffer_size);

--- a/akbench/fifo_bandwidth_test.cc
+++ b/akbench/fifo_bandwidth_test.cc
@@ -11,10 +11,10 @@ int main(int argc, char *argv[]) {
   constexpr uint64_t data_size = 1024;
   constexpr uint64_t buffer_size = 1024;
 
-  const double bandwidth = RunFifoBandwidthBenchmark(
+  const BenchmarkResult result = RunFifoBandwidthBenchmark(
       num_iterations, num_warmups, data_size, buffer_size);
 
-  AKCHECK(bandwidth >= 0.0, "Bandwidth should be non-negative");
+  AKCHECK(result.average >= 0.0, "Bandwidth should be non-negative");
   AKLOG(aklog::LogLevel::INFO, "fifo_bandwidth test passed");
 
   return 0;

--- a/akbench/memcpy_bandwidth.cc
+++ b/akbench/memcpy_bandwidth.cc
@@ -10,8 +10,8 @@
 
 #include "common.h"
 
-double RunMemcpyBandwidthBenchmark(int num_iterations, int num_warmups,
-                                   uint64_t data_size) {
+BenchmarkResult RunMemcpyBandwidthBenchmark(int num_iterations, int num_warmups,
+                                            uint64_t data_size) {
   std::vector<uint8_t> src = GenerateDataToSend(data_size);
   std::vector<uint8_t> dst(data_size, 0);
   std::vector<double> durations;
@@ -32,10 +32,11 @@ double RunMemcpyBandwidthBenchmark(int num_iterations, int num_warmups,
     }
   }
 
-  double bandwidth = CalculateBandwidth(durations, num_iterations, data_size);
+  BenchmarkResult result =
+      CalculateBandwidth(durations, num_iterations, data_size);
   AKLOG(aklog::LogLevel::INFO,
-        std::format("Bandwidth: {}{}", bandwidth / (1 << 30),
-                    GIBYTE_PER_SEC_UNIT));
+        std::format("Bandwidth: {:.3f} ± {:.3f}{}", result.average / (1 << 30),
+                    result.stddev / (1 << 30), GIBYTE_PER_SEC_UNIT));
 
-  return bandwidth;
+  return result;
 }

--- a/akbench/memcpy_bandwidth.h
+++ b/akbench/memcpy_bandwidth.h
@@ -1,6 +1,7 @@
 #pragma once
 
+#include "common.h"
 #include <cstdint>
 
-double RunMemcpyBandwidthBenchmark(int num_iterations, int num_warmups,
-                                   uint64_t data_size);
+BenchmarkResult RunMemcpyBandwidthBenchmark(int num_iterations, int num_warmups,
+                                            uint64_t data_size);

--- a/akbench/memcpy_bandwidth_test.cc
+++ b/akbench/memcpy_bandwidth_test.cc
@@ -10,10 +10,10 @@ int main(int argc, char *argv[]) {
   constexpr int num_warmups = 0;
   constexpr uint64_t data_size = 1024;
 
-  const double bandwidth =
+  const BenchmarkResult result =
       RunMemcpyBandwidthBenchmark(num_iterations, num_warmups, data_size);
 
-  AKCHECK(bandwidth >= 0.0, "Bandwidth should be non-negative");
+  AKCHECK(result.average >= 0.0, "Bandwidth should be non-negative");
   AKLOG(aklog::LogLevel::INFO, "memcpy_bandwidth test passed");
 
   return 0;

--- a/akbench/memcpy_mt_bandwidth.cc
+++ b/akbench/memcpy_mt_bandwidth.cc
@@ -11,8 +11,8 @@
 
 #include "common.h"
 
-double MemcpyInMultiThread(uint64_t n_threads, int num_warmups,
-                           int num_iterations, uint64_t data_size) {
+BenchmarkResult MemcpyInMultiThread(uint64_t n_threads, int num_warmups,
+                                    int num_iterations, uint64_t data_size) {
   std::vector<uint8_t> src = GenerateDataToSend(data_size);
   std::vector<uint8_t> dst(data_size, 0x00);
   uint64_t chunk_size = data_size / n_threads;
@@ -56,22 +56,26 @@ double MemcpyInMultiThread(uint64_t n_threads, int num_warmups,
     }
   }
 
-  double bandwidth = CalculateBandwidth(durations, num_iterations, data_size);
+  BenchmarkResult result =
+      CalculateBandwidth(durations, num_iterations, data_size);
   AKLOG(aklog::LogLevel::INFO,
-        std::format("{} threads bandwidth: {}{}.", n_threads,
-                    bandwidth / (1 << 30), GIBYTE_PER_SEC_UNIT));
+        std::format("{} threads bandwidth: {:.3f} ± {:.3f}{}.", n_threads,
+                    result.average / (1 << 30), result.stddev / (1 << 30),
+                    GIBYTE_PER_SEC_UNIT));
 
-  return bandwidth;
+  return result;
 }
 
-double RunMemcpyMtBandwidthBenchmark(int num_iterations, int num_warmups,
-                                     uint64_t data_size, uint64_t num_threads) {
+BenchmarkResult RunMemcpyMtBandwidthBenchmark(int num_iterations,
+                                              int num_warmups,
+                                              uint64_t data_size,
+                                              uint64_t num_threads) {
   AKLOG(aklog::LogLevel::DEBUG,
         std::format(
             "Starting multi-threaded memcpy bandwidth test with {} threads...",
             num_threads));
-  double bandwidth =
+  BenchmarkResult result =
       MemcpyInMultiThread(num_threads, num_warmups, num_iterations, data_size);
 
-  return bandwidth;
+  return result;
 }

--- a/akbench/memcpy_mt_bandwidth.h
+++ b/akbench/memcpy_mt_bandwidth.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "common.h"
 #include <cstdint>
 
-double RunMemcpyMtBandwidthBenchmark(int num_iterations, int num_warmups,
-                                     uint64_t data_size, uint64_t num_threads);
+BenchmarkResult RunMemcpyMtBandwidthBenchmark(int num_iterations,
+                                              int num_warmups,
+                                              uint64_t data_size,
+                                              uint64_t num_threads);

--- a/akbench/memcpy_mt_bandwidth_test.cc
+++ b/akbench/memcpy_mt_bandwidth_test.cc
@@ -11,10 +11,10 @@ int main(int argc, char *argv[]) {
   constexpr uint64_t data_size = 1024;
   constexpr uint64_t num_threads = 2;
 
-  const double bandwidth = RunMemcpyMtBandwidthBenchmark(
+  const BenchmarkResult result = RunMemcpyMtBandwidthBenchmark(
       num_iterations, num_warmups, data_size, num_threads);
 
-  AKCHECK(bandwidth >= 0.0, "Bandwidth should be non-negative");
+  AKCHECK(result.average >= 0.0, "Bandwidth should be non-negative");
   AKLOG(aklog::LogLevel::INFO, "memcpy_mt_bandwidth test passed");
 
   return 0;

--- a/akbench/mmap_bandwidth.h
+++ b/akbench/mmap_bandwidth.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "common.h"
 #include <cstdint>
 
-double RunMmapBandwidthBenchmark(int num_iterations, int num_warmups,
-                                 uint64_t data_size, uint64_t buffer_size);
+BenchmarkResult RunMmapBandwidthBenchmark(int num_iterations, int num_warmups,
+                                          uint64_t data_size,
+                                          uint64_t buffer_size);

--- a/akbench/mmap_bandwidth_test.cc
+++ b/akbench/mmap_bandwidth_test.cc
@@ -11,10 +11,10 @@ int main(int argc, char *argv[]) {
   constexpr uint64_t data_size = 1024;
   constexpr uint64_t buffer_size = 1024;
 
-  const double bandwidth = RunMmapBandwidthBenchmark(
+  const BenchmarkResult result = RunMmapBandwidthBenchmark(
       num_iterations, num_warmups, data_size, buffer_size);
 
-  AKCHECK(bandwidth >= 0.0, "Bandwidth should be non-negative");
+  AKCHECK(result.average >= 0.0, "Bandwidth should be non-negative");
   AKLOG(aklog::LogLevel::INFO, "mmap_bandwidth test passed");
 
   return 0;

--- a/akbench/mpi_bandwidth.cc
+++ b/akbench/mpi_bandwidth.cc
@@ -161,12 +161,13 @@ int main(int argc, char **argv) {
     }
   }
 
-  double bandwidth =
+  BenchmarkResult result =
       CalculateBandwidth(durations, num_iterations, 2 * data_size);
 
   if (rank == 0) {
     AKLOG(aklog::LogLevel::INFO,
-          std::format("{}{}", bandwidth / (1 << 30), GIBYTE_PER_SEC_UNIT));
+          std::format("{:.3f} ± {:.3f}{}", result.average / (1 << 30),
+                      result.stddev / (1 << 30), GIBYTE_PER_SEC_UNIT));
   }
 
   MPI_Finalize();

--- a/akbench/mq_bandwidth.h
+++ b/akbench/mq_bandwidth.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "common.h"
 #include <cstdint>
 
-double RunMqBandwidthBenchmark(int num_iterations, int num_warmups,
-                               uint64_t data_size, uint64_t buffer_size);
+BenchmarkResult RunMqBandwidthBenchmark(int num_iterations, int num_warmups,
+                                        uint64_t data_size,
+                                        uint64_t buffer_size);

--- a/akbench/mq_bandwidth_test.cc
+++ b/akbench/mq_bandwidth_test.cc
@@ -11,10 +11,10 @@ int main(int argc, char *argv[]) {
   constexpr uint64_t data_size = 1024;
   constexpr uint64_t buffer_size = 1024;
 
-  const double bandwidth = RunMqBandwidthBenchmark(num_iterations, num_warmups,
-                                                   data_size, buffer_size);
+  const BenchmarkResult result = RunMqBandwidthBenchmark(
+      num_iterations, num_warmups, data_size, buffer_size);
 
-  AKCHECK(bandwidth >= 0.0, "Bandwidth should be non-negative");
+  AKCHECK(result.average >= 0.0, "Bandwidth should be non-negative");
   AKLOG(aklog::LogLevel::INFO, "mq_bandwidth test passed");
 
   return 0;

--- a/akbench/pipe_bandwidth.h
+++ b/akbench/pipe_bandwidth.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "common.h"
 #include <cstdint>
 
-double RunPipeBandwidthBenchmark(int num_iterations, int num_warmups,
-                                 uint64_t data_size, uint64_t buffer_size);
+BenchmarkResult RunPipeBandwidthBenchmark(int num_iterations, int num_warmups,
+                                          uint64_t data_size,
+                                          uint64_t buffer_size);

--- a/akbench/pipe_bandwidth_test.cc
+++ b/akbench/pipe_bandwidth_test.cc
@@ -11,10 +11,10 @@ int main(int argc, char *argv[]) {
   constexpr uint64_t data_size = 1024;
   constexpr uint64_t buffer_size = 1024;
 
-  const double bandwidth = RunPipeBandwidthBenchmark(
+  const BenchmarkResult result = RunPipeBandwidthBenchmark(
       num_iterations, num_warmups, data_size, buffer_size);
 
-  AKCHECK(bandwidth >= 0.0, "Bandwidth should be non-negative");
+  AKCHECK(result.average >= 0.0, "Bandwidth should be non-negative");
   AKLOG(aklog::LogLevel::INFO, "pipe_bandwidth test passed");
 
   return 0;

--- a/akbench/semaphore_latency.cc
+++ b/akbench/semaphore_latency.cc
@@ -91,8 +91,9 @@ void ChildProcess(uint64_t loop_size, int total_iterations) {
 
 } // namespace
 
-double RunSemaphoreLatencyBenchmark(int num_iterations, int num_warmups,
-                                    uint64_t loop_size) {
+BenchmarkResult RunSemaphoreLatencyBenchmark(int num_iterations,
+                                             int num_warmups,
+                                             uint64_t loop_size) {
   CleanupSemaphores();
 
   // Create semaphores before forking

--- a/akbench/semaphore_latency.h
+++ b/akbench/semaphore_latency.h
@@ -2,5 +2,8 @@
 
 #include <cstdint>
 
-double RunSemaphoreLatencyBenchmark(int num_iterations, int num_warmups,
-                                    uint64_t loop_size);
+#include "common.h"
+
+BenchmarkResult RunSemaphoreLatencyBenchmark(int num_iterations,
+                                             int num_warmups,
+                                             uint64_t loop_size);

--- a/akbench/semaphore_latency_test.cc
+++ b/akbench/semaphore_latency_test.cc
@@ -10,10 +10,10 @@ int main(int argc, char *argv[]) {
   constexpr int num_warmups = 0;
   constexpr uint64_t loop_size = 10;
 
-  const double latency =
+  const BenchmarkResult result =
       RunSemaphoreLatencyBenchmark(num_iterations, num_warmups, loop_size);
 
-  AKCHECK(latency >= 0.0, "Latency should be non-negative");
+  AKCHECK(result.average >= 0.0, "Latency should be non-negative");
   AKLOG(aklog::LogLevel::INFO, "semaphore_latency test passed");
 
   return 0;

--- a/akbench/shm_bandwidth.h
+++ b/akbench/shm_bandwidth.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "common.h"
 #include <cstdint>
 
-double RunShmBandwidthBenchmark(int num_iterations, int num_warmups,
-                                uint64_t data_size, uint64_t buffer_size);
+BenchmarkResult RunShmBandwidthBenchmark(int num_iterations, int num_warmups,
+                                         uint64_t data_size,
+                                         uint64_t buffer_size);

--- a/akbench/shm_bandwidth_test.cc
+++ b/akbench/shm_bandwidth_test.cc
@@ -11,10 +11,10 @@ int main(int argc, char *argv[]) {
   constexpr uint64_t data_size = 1024;
   constexpr uint64_t buffer_size = 1024;
 
-  const double bandwidth = RunShmBandwidthBenchmark(num_iterations, num_warmups,
-                                                    data_size, buffer_size);
+  const BenchmarkResult result = RunShmBandwidthBenchmark(
+      num_iterations, num_warmups, data_size, buffer_size);
 
-  AKCHECK(bandwidth >= 0.0, "Bandwidth should be non-negative");
+  AKCHECK(result.average >= 0.0, "Bandwidth should be non-negative");
   AKLOG(aklog::LogLevel::INFO, "shm_bandwidth test passed");
 
   return 0;

--- a/akbench/syscall_latency.cc
+++ b/akbench/syscall_latency.cc
@@ -12,8 +12,8 @@
 
 #include "common.h"
 
-double RunStatfsLatencyBenchmark(int num_iterations, int num_warmups,
-                                 uint64_t loop_size) {
+BenchmarkResult RunStatfsLatencyBenchmark(int num_iterations, int num_warmups,
+                                          uint64_t loop_size) {
   AKLOG(aklog::LogLevel::DEBUG,
         std::format("Running statfs benchmark with {} iterations, {} warmups, "
                     "and {} operations per iteration",
@@ -41,8 +41,8 @@ double RunStatfsLatencyBenchmark(int num_iterations, int num_warmups,
   return CalculateOneTripDuration(durations);
 }
 
-double RunFstatfsLatencyBenchmark(int num_iterations, int num_warmups,
-                                  uint64_t loop_size) {
+BenchmarkResult RunFstatfsLatencyBenchmark(int num_iterations, int num_warmups,
+                                           uint64_t loop_size) {
   AKLOG(aklog::LogLevel::DEBUG,
         std::format("Running fstatfs benchmark with {} iterations, {} warmups, "
                     "and {} operations per iteration",
@@ -51,7 +51,7 @@ double RunFstatfsLatencyBenchmark(int num_iterations, int num_warmups,
   int fd = open(".", O_RDONLY);
   if (fd == -1) {
     AKLOG(aklog::LogLevel::ERROR, "Failed to open current directory");
-    return -1.0;
+    return {-1.0, 0.0};
   }
 
   std::vector<double> durations;
@@ -75,8 +75,8 @@ double RunFstatfsLatencyBenchmark(int num_iterations, int num_warmups,
   return CalculateOneTripDuration(durations);
 }
 
-double RunGetpidLatencyBenchmark(int num_iterations, int num_warmups,
-                                 uint64_t loop_size) {
+BenchmarkResult RunGetpidLatencyBenchmark(int num_iterations, int num_warmups,
+                                          uint64_t loop_size) {
   AKLOG(aklog::LogLevel::DEBUG,
         std::format("Running getpid benchmark with {} iterations, {} warmups, "
                     "and {} operations per iteration",

--- a/akbench/syscall_latency.h
+++ b/akbench/syscall_latency.h
@@ -2,9 +2,11 @@
 
 #include <cstdint>
 
-double RunStatfsLatencyBenchmark(int num_iterations, int num_warmups,
-                                 uint64_t loop_size);
-double RunFstatfsLatencyBenchmark(int num_iterations, int num_warmups,
-                                  uint64_t loop_size);
-double RunGetpidLatencyBenchmark(int num_iterations, int num_warmups,
-                                 uint64_t loop_size);
+#include "common.h"
+
+BenchmarkResult RunStatfsLatencyBenchmark(int num_iterations, int num_warmups,
+                                          uint64_t loop_size);
+BenchmarkResult RunFstatfsLatencyBenchmark(int num_iterations, int num_warmups,
+                                           uint64_t loop_size);
+BenchmarkResult RunGetpidLatencyBenchmark(int num_iterations, int num_warmups,
+                                          uint64_t loop_size);

--- a/akbench/syscall_latency_test.cc
+++ b/akbench/syscall_latency_test.cc
@@ -10,10 +10,10 @@ int main(int argc, char *argv[]) {
   constexpr int num_warmups = 0;
   constexpr uint64_t loop_size = 10;
 
-  const double latency =
+  const BenchmarkResult result =
       RunGetpidLatencyBenchmark(num_iterations, num_warmups, loop_size);
 
-  AKCHECK(latency >= 0.0, "Latency should be non-negative");
+  AKCHECK(result.average >= 0.0, "Latency should be non-negative");
   AKLOG(aklog::LogLevel::INFO, "syscall_latency test passed");
 
   return 0;

--- a/akbench/tcp_bandwidth.h
+++ b/akbench/tcp_bandwidth.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "common.h"
 #include <cstdint>
 
-double RunTcpBandwidthBenchmark(int num_iterations, int num_warmups,
-                                uint64_t data_size, uint64_t buffer_size);
+BenchmarkResult RunTcpBandwidthBenchmark(int num_iterations, int num_warmups,
+                                         uint64_t data_size,
+                                         uint64_t buffer_size);

--- a/akbench/tcp_bandwidth_test.cc
+++ b/akbench/tcp_bandwidth_test.cc
@@ -11,10 +11,10 @@ int main(int argc, char *argv[]) {
   constexpr uint64_t data_size = 1024;
   constexpr uint64_t buffer_size = 1024;
 
-  const double bandwidth = RunTcpBandwidthBenchmark(num_iterations, num_warmups,
-                                                    data_size, buffer_size);
+  const BenchmarkResult result = RunTcpBandwidthBenchmark(
+      num_iterations, num_warmups, data_size, buffer_size);
 
-  AKCHECK(bandwidth >= 0.0, "Bandwidth should be non-negative");
+  AKCHECK(result.average >= 0.0, "Bandwidth should be non-negative");
   AKLOG(aklog::LogLevel::INFO, "tcp_bandwidth test passed");
 
   return 0;

--- a/akbench/uds_bandwidth.h
+++ b/akbench/uds_bandwidth.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "common.h"
 #include <cstdint>
 
-double RunUdsBandwidthBenchmark(int num_iterations, int num_warmups,
-                                uint64_t data_size, uint64_t buffer_size);
+BenchmarkResult RunUdsBandwidthBenchmark(int num_iterations, int num_warmups,
+                                         uint64_t data_size,
+                                         uint64_t buffer_size);

--- a/akbench/uds_bandwidth_test.cc
+++ b/akbench/uds_bandwidth_test.cc
@@ -11,10 +11,10 @@ int main(int argc, char *argv[]) {
   constexpr uint64_t data_size = 256;
   constexpr uint64_t buffer_size = 256;
 
-  const double bandwidth = RunUdsBandwidthBenchmark(num_iterations, num_warmups,
-                                                    data_size, buffer_size);
+  const BenchmarkResult result = RunUdsBandwidthBenchmark(
+      num_iterations, num_warmups, data_size, buffer_size);
 
-  AKCHECK(bandwidth >= 0.0, "Bandwidth should be non-negative");
+  AKCHECK(result.average >= 0.0, "Bandwidth should be non-negative");
   AKLOG(aklog::LogLevel::INFO, "uds_bandwidth test passed");
 
   return 0;


### PR DESCRIPTION
- Add BenchmarkResult struct to hold average and standard deviation
- Update CalculateBandwidth and CalculateOneTripDuration functions
- Modify all benchmark implementations to return BenchmarkResult
- Display results in "X.XXX ± Y.YYY units" format using σ symbol
- Update all test files to use new BenchmarkResult structure