### PR TITLE
Convert snake_case function names to PascalCase

### DIFF
--- a/akbench/akbench.cc
+++ b/akbench/akbench.cc
@@ -42,7 +42,7 @@ static std::string g_log_level = "WARNING";
 
 constexpr uint64_t DEFAULT_BUFFER_SIZE = 1 << 20; // 1 MiByte
 
-void print_usage(const char *program_name) {
+void PrintUsage(const char *program_name) {
   std::cout << R"(Usage: )" << program_name << R"( <TYPE> [OPTIONS]
 
 Unified benchmark tool for measuring system performance.
@@ -356,49 +356,49 @@ int main(int argc, char *argv[]) {
     try {
       switch (opt) {
       case 'i':
-        g_num_iterations = parse_int(optarg);
+        g_num_iterations = ParseInt(optarg);
         break;
       case 'w':
-        g_num_warmups = parse_int(optarg);
+        g_num_warmups = ParseInt(optarg);
         break;
       case 'l':
-        g_loop_size = parse_uint64(optarg);
+        g_loop_size = ParseUint64(optarg);
         break;
       case 'd':
-        g_data_size = parse_uint64(optarg).value();
+        g_data_size = ParseUint64(optarg).value();
         break;
       case 'b':
-        g_buffer_size = parse_uint64(optarg);
+        g_buffer_size = ParseUint64(optarg);
         break;
       case 'n':
-        g_num_threads = parse_uint64(optarg);
+        g_num_threads = ParseUint64(optarg);
         break;
       case 256: // --log-level
         g_log_level = optarg;
         break;
       case 'h':
-        print_usage(program_name);
+        PrintUsage(program_name);
         return 0;
       case '?':
         // getopt_long already printed an error message
         return 1;
       default:
-        print_error_and_exit(program_name, "Unknown option");
+        PrintErrorAndExit(program_name, "Unknown option");
       }
     } catch (const std::exception &e) {
-      print_error_and_exit(program_name, e.what());
+      PrintErrorAndExit(program_name, e.what());
     }
   }
 
   // Check for exactly one positional argument (the benchmark type)
   if (optind >= argc) {
-    print_error_and_exit(program_name, "Missing required argument: TYPE");
+    PrintErrorAndExit(program_name, "Missing required argument: TYPE");
   }
 
   if (optind + 1 < argc) {
-    print_error_and_exit(program_name,
-                         "Too many arguments. Expected only TYPE, got: " +
-                             std::string(argv[optind + 1]));
+    PrintErrorAndExit(program_name,
+                      "Too many arguments. Expected only TYPE, got: " +
+                          std::string(argv[optind + 1]));
   }
 
   // Get the benchmark type from the positional argument

--- a/akbench/barrier_latency.cc
+++ b/akbench/barrier_latency.cc
@@ -38,7 +38,7 @@ BenchmarkResult RunBarrierLatencyBenchmark(int num_iterations, int num_warmups,
           "Running barrier latency benchmark with {} processes, {} iterations",
           NUM_PROCESSES, loop_size));
 
-  auto run_single_benchmark = [&]() -> double {
+  auto RunSingleBenchmark = [&]() -> double {
     std::vector<int> pids;
 
     // Fork child processes (only 1 child process for 2-process barrier)
@@ -83,7 +83,7 @@ BenchmarkResult RunBarrierLatencyBenchmark(int num_iterations, int num_warmups,
   for (int i = 0; i < num_warmups; ++i) {
     AKLOG(aklog::LogLevel::DEBUG,
           std::format("Warmup iteration {}/{}", i + 1, num_warmups));
-    run_single_benchmark();
+    RunSingleBenchmark();
     SenseReversingBarrier::ClearResource(BARRIER_ID);
   }
 
@@ -92,7 +92,7 @@ BenchmarkResult RunBarrierLatencyBenchmark(int num_iterations, int num_warmups,
   for (int i = 0; i < num_iterations; ++i) {
     AKLOG(aklog::LogLevel::DEBUG,
           std::format("Measurement iteration {}/{}", i + 1, num_iterations));
-    double latency_ns = run_single_benchmark();
+    double latency_ns = RunSingleBenchmark();
     measurements.push_back(latency_ns);
     SenseReversingBarrier::ClearResource(BARRIER_ID);
   }

--- a/akbench/barrier_test.cc
+++ b/akbench/barrier_test.cc
@@ -283,7 +283,7 @@ static std::string g_test_type = "constructor";
 static int g_num_processes = 2;
 static int g_num_iterations = 20;
 
-void print_usage(const char *program_name) {
+void PrintUsage(const char *program_name) {
   std::cout << R"(Usage: )" << program_name << R"( [OPTIONS]
 
 Sense Reversing Barrier Test
@@ -320,29 +320,29 @@ int main(int argc, char *argv[]) {
         g_test_type = optarg;
         break;
       case 'p':
-        g_num_processes = parse_int(optarg);
+        g_num_processes = ParseInt(optarg);
         break;
       case 'i':
-        g_num_iterations = parse_int(optarg);
+        g_num_iterations = ParseInt(optarg);
         break;
       case 'h':
-        print_usage(program_name);
+        PrintUsage(program_name);
         return 0;
       case '?':
         // getopt_long already printed an error message
         return 1;
       default:
-        print_error_and_exit(program_name, "Unknown option");
+        PrintErrorAndExit(program_name, "Unknown option");
       }
     } catch (const std::exception &e) {
-      print_error_and_exit(program_name, e.what());
+      PrintErrorAndExit(program_name, e.what());
     }
   }
 
   // Check for extra arguments
   if (optind < argc) {
-    print_error_and_exit(program_name,
-                         "Unexpected argument: " + std::string(argv[optind]));
+    PrintErrorAndExit(program_name,
+                      "Unexpected argument: " + std::string(argv[optind]));
   }
 
   const std::string &test_type = g_test_type;

--- a/akbench/getopt_utils.h
+++ b/akbench/getopt_utils.h
@@ -10,7 +10,7 @@
 // Helper functions for parsing command line arguments with getopt_long
 
 // Parse a string to uint64_t
-inline std::optional<uint64_t> parse_uint64(const std::string &str) {
+inline std::optional<uint64_t> ParseUint64(const std::string &str) {
   if (str.empty()) {
     return std::nullopt;
   }
@@ -51,7 +51,7 @@ inline std::optional<uint64_t> parse_uint64(const std::string &str) {
 }
 
 // Parse a string to int
-inline int parse_int(const std::string &str) {
+inline int ParseInt(const std::string &str) {
   if (str.empty()) {
     throw std::invalid_argument("Empty string cannot be parsed as int");
   }
@@ -67,8 +67,8 @@ inline int parse_int(const std::string &str) {
 }
 
 // Helper to print an error message and exit
-inline void print_error_and_exit(const std::string &program_name,
-                                 const std::string &error_msg) {
+inline void PrintErrorAndExit(const std::string &program_name,
+                              const std::string &error_msg) {
   std::fprintf(stderr, "%s: %s\n", program_name.c_str(), error_msg.c_str());
   std::fprintf(stderr, "Try '%s --help' for more information.\n",
                program_name.c_str());

--- a/akbench/mpi_bandwidth.cc
+++ b/akbench/mpi_bandwidth.cc
@@ -18,7 +18,7 @@ static int g_num_iterations = 10;
 static int g_num_warmups = 3;
 static uint64_t g_data_size = 1024 * 1024; // 1MB default
 
-void print_usage(const char *program_name) {
+void PrintUsage(const char *program_name) {
   std::cout << R"(Usage: )" << program_name << R"( [OPTIONS]
 
 Ping-pong benchmark tool for measuring MPI bandwidth.
@@ -50,25 +50,25 @@ int main(int argc, char **argv) {
     try {
       switch (opt) {
       case 'i':
-        g_num_iterations = parse_int(optarg);
+        g_num_iterations = ParseInt(optarg);
         break;
       case 'w':
-        g_num_warmups = parse_int(optarg);
+        g_num_warmups = ParseInt(optarg);
         break;
       case 'd':
-        g_data_size = parse_uint64(optarg).value();
+        g_data_size = ParseUint64(optarg).value();
         break;
       case 'h':
-        print_usage(program_name);
+        PrintUsage(program_name);
         return 0;
       case '?':
         // getopt_long already printed an error message
         return 1;
       default:
-        print_error_and_exit(program_name, "Unknown option");
+        PrintErrorAndExit(program_name, "Unknown option");
       }
     } catch (const std::exception &e) {
-      print_error_and_exit(program_name, e.what());
+      PrintErrorAndExit(program_name, e.what());
     }
   }
 


### PR DESCRIPTION
## Summary
- Convert all project-specific function names from snake_case to PascalCase naming convention
- Update function definitions and all call sites across the codebase
- Maintain all existing functionality while improving naming consistency

## Changes
- `parse_uint64` → `ParseUint64`
- `parse_int` → `ParseInt` 
- `print_error_and_exit` → `PrintErrorAndExit`
- `print_usage` → `PrintUsage`
- `run_single_benchmark` → `RunSingleBenchmark`

## Files Modified
- `akbench/getopt_utils.h` - Function definitions
- `akbench/akbench.cc` - Function definition and calls
- `akbench/mpi_bandwidth.cc` - Function definition and calls
- `akbench/barrier_test.cc` - Function definition and calls
- `akbench/barrier_latency.cc` - Lambda function and calls

## Test Plan
- [x] All code formatted with `./scripts/format.sh`
- [x] Project builds successfully with `./scripts/build.sh`
- [x] All 19 tests pass
- [x] No functional changes, only naming convention updates