### PR TITLE
Add configurable parameters to run_lmbench.py for CI optimization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,24 @@ jobs:
         test -f /tmp/akbench_install/bin/akbench
         /tmp/akbench_install/bin/akbench --help
         /tmp/akbench_install/bin/akbench latency_atomic --num-iterations=3 --num-warmups=1
+  benchmark-comparison-test:
+    name: Benchmark comparison scripts
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential python3 python3-pip python3-venv git libtirpc-dev openmpi-bin libopenmpi-dev
+        pip3 install --upgrade pip torch
+    - name: Test LMbench benchmark script
+      run: |
+        cd benchmark_comparison
+        ./run_lmbench.sh --log-level INFO
+    - name: Test Gloo benchmark script
+      run: |
+        cd benchmark_comparison
+        ./gloo_benchmark.sh --log-level INFO --data-size=1048576 --num-iterations=2 --num-warmups=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Test LMbench benchmark script
       run: |
         cd benchmark_comparison
-        ./run_lmbench.sh --log-level INFO
+        ./run_lmbench.sh --log-level INFO --data-size=1M --num-iterations=3 --num-warmups=1
     - name: Test Gloo benchmark script
       run: |
         cd benchmark_comparison

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,4 +79,4 @@ jobs:
     - name: Test Gloo benchmark script
       run: |
         cd benchmark_comparison
-        ./gloo_benchmark.sh --log-level INFO --data-size=1048576 --num-iterations=2 --num-warmups=1
+        ./gloo_benchmark.sh --log-level INFO --data-size=1048576

--- a/README.md
+++ b/README.md
@@ -173,48 +173,4 @@ $ uname -a
 Linux masumi 6.14.0-24-generic #24~24.04.3-Ubuntu SMP PREEMPT_DYNAMIC Mon Jul  7 16:39:17 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
 ```
 
-## Benchmark results using existing tools
 
-### memcpy
-
-```
-$ perf bench mem memcpy --size 1GB
-# Running 'mem/memcpy' benchmark:
-# function 'default' (Default memcpy() provided by glibc)
-# Copying 1GB bytes ...
-
-      17.304930 GB/sec
-# function 'x86-64-unrolled' (unrolled memcpy() in arch/x86/lib/memcpy_64.S)
-# Copying 1GB bytes ...
-
-       9.950447 GB/sec
-# function 'x86-64-movsq' (movsq-based memcpy() in arch/x86/lib/memcpy_64.S)
-# Copying 1GB bytes ...
-
-      19.133263 GB/sec
-```
-
-### TCP
-
-#### localhost
-
-```
-$ iperf3 -c localhost --format g -bytes 1g
-Connecting to host localhost, port 5201
-[  5] local 127.0.0.1 port 59876 connected to 127.0.0.1 port 5201
-[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
-[  5]   0.00-1.00   sec  4.83 GBytes  4.82 GBytes/sec    0   6.56 MBytes       
-[  5]   1.00-2.00   sec  3.09 GBytes  3.10 GBytes/sec    0   6.56 MBytes       
-[  5]   2.00-3.00   sec  1.84 GBytes  1.84 GBytes/sec    0   6.56 MBytes       
-[  5]   3.00-4.00   sec  1.90 GBytes  1.90 GBytes/sec    0   6.56 MBytes       
-[  5]   4.00-5.00   sec  4.30 GBytes  4.30 GBytes/sec    0   6.56 MBytes       
-[  5]   5.00-6.00   sec  5.37 GBytes  5.37 GBytes/sec    0   6.56 MBytes       
-[  5]   6.00-7.00   sec  5.00 GBytes  5.00 GBytes/sec    0   6.56 MBytes       
-[  5]   7.00-8.00   sec  4.23 GBytes  4.23 GBytes/sec    0   6.56 MBytes       
-[  5]   8.00-9.00   sec  4.17 GBytes  4.17 GBytes/sec    0   6.56 MBytes       
-[  5]   9.00-10.00  sec  5.35 GBytes  5.35 GBytes/sec    0   6.56 MBytes       
-- - - - - - - - - - - - - - - - - - - - - - - - -
-[ ID] Interval           Transfer     Bitrate         Retr
-[  5]   0.00-10.00  sec  51.8 GBytes  5.18 GBytes/sec    0             sender
-[  5]   0.00-10.00  sec  51.8 GBytes  5.18 GBytes/sec                  receiver
-```

--- a/README.md
+++ b/README.md
@@ -41,8 +41,64 @@ bandwidth_mmap: 10.446 GiByte/sec
 bandwidth_shm: 10.452 GiByte/sec
 ```
 
-## Machine information which was used to run the benchmark below
+## Machine information
 
+All numbers in this repository were measured on the following my machine:
+
+### CPU
+```
+$ lscpu
+Architecture:                         x86_64
+CPU op-mode(s):                       32-bit, 64-bit
+Address sizes:                        48 bits physical, 48 bits virtual
+Byte Order:                           Little Endian
+CPU(s):                               32
+On-line CPU(s) list:                  0-31
+Vendor ID:                            AuthenticAMD
+Model name:                           AMD Ryzen 9 5950X 16-Core Processor
+CPU family:                           25
+Model:                                33
+Thread(s) per core:                   2
+Core(s) per socket:                   16
+Socket(s):                            1
+Stepping:                             0
+Frequency boost:                      enabled
+CPU(s) scaling MHz:                   50%
+CPU max MHz:                          5086.0000
+CPU min MHz:                          550.0000
+BogoMIPS:                             6786.93
+Flags:                                fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid extd_apicid aperfmperf rapl pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb cat_l3 cdp_l3 hw_pstate ssbd mba ibrs ibpb stibp vmmcall fsgsbase bmi1 avx2 smep bmi2 invpcid cqm rdt_a rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local user_shstk clzero irperf xsaveerptr rdpru wbnoinvd arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmload vgif v_spec_ctrl umip pku ospke vaes vpclmulqdq rdpid overflow_recov succor smca debug_swap
+Virtualization:                       AMD-V
+L1d cache:                            512 KiB (16 instances)
+L1i cache:                            512 KiB (16 instances)
+L2 cache:                             8 MiB (16 instances)
+L3 cache:                             64 MiB (2 instances)
+NUMA node(s):                         1
+NUMA node0 CPU(s):                    0-31
+Vulnerability Gather data sampling:   Not affected
+Vulnerability Ghostwrite:             Not affected
+Vulnerability Itlb multihit:          Not affected
+Vulnerability L1tf:                   Not affected
+Vulnerability Mds:                    Not affected
+Vulnerability Meltdown:               Not affected
+Vulnerability Mmio stale data:        Not affected
+Vulnerability Reg file data sampling: Not affected
+Vulnerability Retbleed:               Not affected
+Vulnerability Spec rstack overflow:   Mitigation; Safe RET
+Vulnerability Spec store bypass:      Mitigation; Speculative Store Bypass disabled via prctl
+Vulnerability Spectre v1:             Mitigation; usercopy/swapgs barriers and __user pointer sanitization
+Vulnerability Spectre v2:             Mitigation; Retpolines; IBPB conditional; IBRS_FW; STIBP always-on; RSB filling; PBRSB-eIBRS Not affected; BHI Not affected
+Vulnerability Srbds:                  Not affected
+Vulnerability Tsx async abort:        Not affected
+```
+
+### OS
+```
+$ uname -a
+Linux masumi 6.14.0-24-generic #24~24.04.3-Ubuntu SMP PREEMPT_DYNAMIC Mon Jul  7 16:39:17 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
+```
+
+### DRAM
 ```
 $ sudo lshw -class memory
   *-firmware
@@ -121,56 +177,3 @@ $ sudo lshw -class memory
        capabilities: pipeline-burst internal write-back unified
        configuration: level=3
 ```
-
-```
-$ lscpu
-Architecture:                         x86_64
-CPU op-mode(s):                       32-bit, 64-bit
-Address sizes:                        48 bits physical, 48 bits virtual
-Byte Order:                           Little Endian
-CPU(s):                               32
-On-line CPU(s) list:                  0-31
-Vendor ID:                            AuthenticAMD
-Model name:                           AMD Ryzen 9 5950X 16-Core Processor
-CPU family:                           25
-Model:                                33
-Thread(s) per core:                   2
-Core(s) per socket:                   16
-Socket(s):                            1
-Stepping:                             0
-Frequency boost:                      enabled
-CPU(s) scaling MHz:                   50%
-CPU max MHz:                          5086.0000
-CPU min MHz:                          550.0000
-BogoMIPS:                             6786.93
-Flags:                                fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx mmxext fxsr_opt pdpe1gb rdtscp lm constant_tsc rep_good nopl xtopology nonstop_tsc cpuid extd_apicid aperfmperf rapl pni pclmulqdq monitor ssse3 fma cx16 sse4_1 sse4_2 movbe popcnt aes xsave avx f16c rdrand lahf_lm cmp_legacy svm extapic cr8_legacy abm sse4a misalignsse 3dnowprefetch osvw ibs skinit wdt tce topoext perfctr_core perfctr_nb bpext perfctr_llc mwaitx cpb cat_l3 cdp_l3 hw_pstate ssbd mba ibrs ibpb stibp vmmcall fsgsbase bmi1 avx2 smep bmi2 invpcid cqm rdt_a rdseed adx smap clflushopt clwb sha_ni xsaveopt xsavec xgetbv1 xsaves cqm_llc cqm_occup_llc cqm_mbm_total cqm_mbm_local user_shstk clzero irperf xsaveerptr rdpru wbnoinvd arat npt lbrv svm_lock nrip_save tsc_scale vmcb_clean flushbyasid decodeassists pausefilter pfthreshold avic v_vmsave_vmload vgif v_spec_ctrl umip pku ospke vaes vpclmulqdq rdpid overflow_recov succor smca debug_swap
-Virtualization:                       AMD-V
-L1d cache:                            512 KiB (16 instances)
-L1i cache:                            512 KiB (16 instances)
-L2 cache:                             8 MiB (16 instances)
-L3 cache:                             64 MiB (2 instances)
-NUMA node(s):                         1
-NUMA node0 CPU(s):                    0-31
-Vulnerability Gather data sampling:   Not affected
-Vulnerability Ghostwrite:             Not affected
-Vulnerability Itlb multihit:          Not affected
-Vulnerability L1tf:                   Not affected
-Vulnerability Mds:                    Not affected
-Vulnerability Meltdown:               Not affected
-Vulnerability Mmio stale data:        Not affected
-Vulnerability Reg file data sampling: Not affected
-Vulnerability Retbleed:               Not affected
-Vulnerability Spec rstack overflow:   Mitigation; Safe RET
-Vulnerability Spec store bypass:      Mitigation; Speculative Store Bypass disabled via prctl
-Vulnerability Spectre v1:             Mitigation; usercopy/swapgs barriers and __user pointer sanitization
-Vulnerability Spectre v2:             Mitigation; Retpolines; IBPB conditional; IBRS_FW; STIBP always-on; RSB filling; PBRSB-eIBRS Not affected; BHI Not affected
-Vulnerability Srbds:                  Not affected
-Vulnerability Tsx async abort:        Not affected
-```
-
-```
-$ uname -a
-Linux masumi 6.14.0-24-generic #24~24.04.3-Ubuntu SMP PREEMPT_DYNAMIC Mon Jul  7 16:39:17 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
-```
-
-

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ cmake --install build
 
 ## How to run
 ```bash
-$ If you haven't installed it, ./build/akbench/akbench all
+$ # If you haven't installed it, ./build/akbench/akbench all
 $ akbench all
 Running all latency tests:
 

--- a/benchmark_comparison/README.md
+++ b/benchmark_comparison/README.md
@@ -16,3 +16,45 @@ lat_syscall fstat: 316.10 ns
 lat_syscall open: 1976.90 ns
 lat_sem: 1220.70 ns
 ```
+
+## perf bench
+
+```
+$ perf bench mem memcpy --size 1GB
+# Running 'mem/memcpy' benchmark:
+# function 'default' (Default memcpy() provided by glibc)
+# Copying 1GB bytes ...
+
+      17.304930 GB/sec
+# function 'x86-64-unrolled' (unrolled memcpy() in arch/x86/lib/memcpy_64.S)
+# Copying 1GB bytes ...
+
+       9.950447 GB/sec
+# function 'x86-64-movsq' (movsq-based memcpy() in arch/x86/lib/memcpy_64.S)
+# Copying 1GB bytes ...
+
+      19.133263 GB/sec
+```
+
+## iperf3
+
+```
+$ iperf3 -c localhost --format g -bytes 1g
+Connecting to host localhost, port 5201
+[  5] local 127.0.0.1 port 59876 connected to 127.0.0.1 port 5201
+[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
+[  5]   0.00-1.00   sec  4.83 GBytes  4.82 GBytes/sec    0   6.56 MBytes       
+[  5]   1.00-2.00   sec  3.09 GBytes  3.10 GBytes/sec    0   6.56 MBytes       
+[  5]   2.00-3.00   sec  1.84 GBytes  1.84 GBytes/sec    0   6.56 MBytes       
+[  5]   3.00-4.00   sec  1.90 GBytes  1.90 GBytes/sec    0   6.56 MBytes       
+[  5]   4.00-5.00   sec  4.30 GBytes  4.30 GBytes/sec    0   6.56 MBytes       
+[  5]   5.00-6.00   sec  5.37 GBytes  5.37 GBytes/sec    0   6.56 MBytes       
+[  5]   6.00-7.00   sec  5.00 GBytes  5.00 GBytes/sec    0   6.56 MBytes       
+[  5]   7.00-8.00   sec  4.23 GBytes  4.23 GBytes/sec    0   6.56 MBytes       
+[  5]   8.00-9.00   sec  4.17 GBytes  4.17 GBytes/sec    0   6.56 MBytes       
+[  5]   9.00-10.00  sec  5.35 GBytes  5.35 GBytes/sec    0   6.56 MBytes       
+- - - - - - - - - - - - - - - - - - - - - - - - -
+[ ID] Interval           Transfer     Bitrate         Retr
+[  5]   0.00-10.00  sec  51.8 GBytes  5.18 GBytes/sec    0             sender
+[  5]   0.00-10.00  sec  51.8 GBytes  5.18 GBytes/sec                  receiver
+```

--- a/benchmark_comparison/README.md
+++ b/benchmark_comparison/README.md
@@ -17,6 +17,13 @@ lat_syscall open: 1976.90 ns
 lat_sem: 1220.70 ns
 ```
 
+## Send/Recv using gloo
+```
+$ ./gloo_benchmark.sh
+...
+gloo_bandwidth: 5.75 GiB/s
+```
+
 ## perf bench
 
 ```

--- a/benchmark_comparison/gloo_benchmark.py
+++ b/benchmark_comparison/gloo_benchmark.py
@@ -56,7 +56,7 @@ def setup_argument_parser():
     )
 
     parser.add_argument(
-        "--data_size",
+        "--data-size",
         type=int,
         default=1024**3,
         help="Size of data to send/recv in bytes. Default is 1GiByte.",


### PR DESCRIPTION
## Summary

This PR adds configurable command-line parameters to `run_lmbench.py` and optimizes CI execution time by using smaller data sizes for benchmark testing.

### Changes Made

- **Added Command-Line Options:**
  - `--data-size` with K/M/G suffix support (default: "1G")
  - `--num-iterations` for benchmark iterations (default: 10)  
  - `--num-warmups` for warmup iterations (default: 3)

- **Enhanced Functionality:**
  - Added `parse_data_size()` helper function for human-readable size parsing
  - Updated all benchmark functions to accept configurable parameters
  - Maintained full backward compatibility with existing defaults

- **CI Optimization:**
  - Updated CI job to use `--data-size=1M --num-iterations=3 --num-warmups=1`
  - Reduces data size from 1 GiB to 1 MiB (1000x smaller)
  - Reduces iterations from 10 to 3 (3.3x fewer)
  - Significantly faster CI execution while maintaining test coverage

### Test Plan

- [x] Verified help output shows new command-line options
- [x] Tested script with small parameters produces expected output format  
- [x] Confirmed backward compatibility (runs same as before without arguments)
- [x] Validated CI job will use optimized parameters

### Benefits

- **Faster CI:** Dramatically reduced execution time for benchmark comparison testing
- **Flexibility:** Users can customize benchmark parameters for their specific needs
- **Compatibility:** No breaking changes to existing usage patterns
- **Maintainability:** Cleaner parameter passing throughout the codebase